### PR TITLE
Currency parameter to support Alipay create_forex_trade service

### DIFF
--- a/src/Omnipay/Alipay/Message/ExpressPurchaseRequest.php
+++ b/src/Omnipay/Alipay/Message/ExpressPurchaseRequest.php
@@ -36,6 +36,7 @@ class ExpressPurchaseRequest extends BasePurchaseRequest
             "out_trade_no"      => $this->getOutTradeNo(),
             "subject"           => $this->getSubject(),
             "total_fee"         => $this->getTotalFee(),
+            "currency"          => $this->getCurrency(),
             "body"              => $this->getBody(),
             "show_url"          => $this->getShowUrl(),
             "anti_phishing_key" => $this->getAntiPhishingKey(),
@@ -58,6 +59,16 @@ class ExpressPurchaseRequest extends BasePurchaseRequest
     public function setTotalFee($value)
     {
         $this->setParameter('total_fee', $value);
+    }
+
+    public function getCurrency()
+    {
+        return $this->getParameter('currency');
+    }
+
+    public function setCurrency($value)
+    {
+        $this->setParameter('currency', $value);
     }
 
     public function getDefaultBank()


### PR DESCRIPTION
Added currency parameter so omnipay-alipay can be used with the Alipay create_forex_trade service. Currency is a required field for the create_forex_trade service.
