### PR TITLE
bug fix: The Alipay return_url calls do not include the sign parameter.

### DIFF
--- a/src/Omnipay/Alipay/Message/ExpressCompletePurchaseRequest.php
+++ b/src/Omnipay/Alipay/Message/ExpressCompletePurchaseRequest.php
@@ -27,7 +27,7 @@ class ExpressCompletePurchaseRequest extends AbstractRequest
     public function getData()
     {
         $this->validate('request_params', 'transport', 'partner', 'ca_cert_path', 'sign_type', 'key');
-        $this->validateRequestParams('sign', 'trade_status', 'out_trade_no', 'trade_no');
+        $this->validateRequestParams('trade_status', 'out_trade_no', 'trade_no');
         return $this->getParameters();
     }
 
@@ -209,14 +209,18 @@ class ExpressCompletePurchaseRequest extends AbstractRequest
     public function sendData($data)
     {
         $notify_id = $this->getNotifyId();
+        $sign = $this->getRequestParam('sign');
+        $validateSign = !empty($sign);
 
         $this->verifyResponse = 'true';
         if (!is_null($notify_id)) {
             $this->verifyResponse = $this->getVerifyResponse($this->getNotifyId());
+            $validateSign = true;
         }
+        
         $data                    = array();
         $data['verify_response'] = $this->verifyResponse;
-        if ($this->isResponseOk($this->verifyResponse) && $this->isSignMatch()) {
+        if ($this->isResponseOk($this->verifyResponse) && (!$validateSign || $this->isSignMatch())) {
             $data['verify_success'] = true;
         } else {
             $data['verify_success'] = false;


### PR DESCRIPTION
Only validate the sign parameter if it's included or if the request
includes the notify_id parameter too.
