### PR TITLE
Add SHA256 algorithm support to AopNotifyRequest

### DIFF
--- a/src/Requests/AopNotifyRequest.php
+++ b/src/Requests/AopNotifyRequest.php
@@ -123,8 +123,13 @@ class AopNotifyRequest extends AbstractAopRequest
         $content = $signer->getContentToSign();
 
         $sign = $this->params->get('sign');
-
-        $match = (new Signer)->verifyWithRSA($content, $sign, $this->getAlipayPublicKey());
+        $sign_type = $this->params->get('sign_type');
+        
+        if ($sign_type == 'RSA2') {
+            $match = (new Signer)->verifyWithRSA($content, $sign, $this->getAlipayPublicKey(), OPENSSL_ALGO_SHA256);
+        } else {
+            $match = (new Signer)->verifyWithRSA($content, $sign, $this->getAlipayPublicKey());
+        }
 
         if (! $match) {
             throw new InvalidRequestException('The signature is not match');


### PR DESCRIPTION
At the moment, AopNotifyRequest only supports SHA1 algorithm. If app uses Alipay SH256 key, then this function will always return "The signature is not match" Exception.