### PR TITLE
Fixed a PHP7 warning.

### DIFF
--- a/src/Responses/AbstractAopResponse.php
+++ b/src/Responses/AbstractAopResponse.php
@@ -25,7 +25,7 @@ abstract class AbstractAopResponse extends AbstractResponse
     }
 
 
-    public function getAlipayResponse($key)
+    public function getAlipayResponse($key = NULL)
     {
         if ($key) {
             return array_get($this->data, "{$this->key}.{$key}");


### PR DESCRIPTION
I am not sure about PHP 5.5, but for PHP 7, 

`$response->getAlipayResponse();` will trigger the warning below:

> Warning: Missing argument 1 for Omnipay\Alipay\Responses\AbstractAopResponse::getAlipayResponse(), called in .....