### PR TITLE
Fix app return validate exception

### DIFF
--- a/src/Requests/AopVerifyAppPayReturnRequest.php
+++ b/src/Requests/AopVerifyAppPayReturnRequest.php
@@ -46,7 +46,7 @@ class AopVerifyAppPayReturnRequest extends AbstractAopRequest
     /**
      * @throws InvalidRequestException
      */
-    public function validate()
+    public function validate(...$args)
     {
         parent::validate(
             'result'


### PR DESCRIPTION
Declaration of Omnipay\Alipay\Requests\AopVerifyAppPayReturnRequest::validate() should be compatible with Omnipay\Common\Message\AbstractRequest::validate(...$args)
